### PR TITLE
feat(socials): add GitHub activity graph and polish Discord card

### DIFF
--- a/src/components/svelte/SocialGithubGraph.svelte
+++ b/src/components/svelte/SocialGithubGraph.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  export let username = "devrohit06";
+
+  type Day = { date: string; count: number; level: number };
+
+  let columns: (Day | null)[][] = [];
+  let monthLabels: { index: number; label: string }[] = [];
+  let total = 0;
+  let loading = true;
+  let error = false;
+  let hovered = "";
+
+  const MONTHS = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+
+  // Map the 0-4 contribution level to the site's GitHub activity CSS tokens.
+  const levelVar = (lvl: number) =>
+    lvl <= 0
+      ? "var(--github-activity-level0)"
+      : lvl === 1
+        ? "var(--github-activity-level1)"
+        : lvl === 2
+          ? "var(--github-activity-level4)"
+          : lvl === 3
+            ? "var(--github-activity-level8)"
+            : "var(--github-activity-level12)";
+
+  const pretty = (d: Day) => {
+    const label = new Date(d.date).toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
+    });
+    const n = d.count;
+    return `${n === 0 ? "No" : n} contribution${n === 1 ? "" : "s"} on ${label}`;
+  };
+
+  async function load() {
+    try {
+      loading = true;
+      error = false;
+      const res = await fetch(
+        `https://github-contributions-api.jogruber.de/v4/${username}?y=last`,
+      );
+      if (!res.ok) throw new Error(String(res.status));
+      const data = await res.json();
+
+      const contribs: Day[] = data.contributions ?? [];
+      if (contribs.length === 0) throw new Error("no data");
+
+      total =
+        data.total?.lastYear ??
+        contribs.reduce((a: number, c) => a + (c.count || 0), 0);
+
+      // Pad the leading days so the first column starts on Sunday.
+      const lead = new Date(contribs[0].date).getDay();
+      const cells: (Day | null)[] = [];
+      for (let i = 0; i < lead; i++) cells.push(null);
+      for (const c of contribs) cells.push(c);
+
+      const cols: (Day | null)[][] = [];
+      for (let i = 0; i < cells.length; i += 7) cols.push(cells.slice(i, i + 7));
+      columns = cols;
+
+      // First column of each new month gets a label.
+      const labels: { index: number; label: string }[] = [];
+      let prevMonth = -1;
+      cols.forEach((col, i) => {
+        const firstDay = col.find((d) => d) as Day | undefined;
+        if (!firstDay) return;
+        const m = new Date(firstDay.date).getMonth();
+        if (m !== prevMonth) {
+          labels.push({ index: i, label: MONTHS[m] });
+          prevMonth = m;
+        }
+      });
+      monthLabels = labels;
+
+      hovered = `${total.toLocaleString()} contributions in the last year`;
+      loading = false;
+    } catch (e) {
+      error = true;
+      loading = false;
+    }
+  }
+
+  onMount(load);
+</script>
+
+<div class="gh">
+  {#if loading}
+    <div class="gh-state">Loading contributions…</div>
+  {:else if error}
+    <div class="gh-state">
+      Couldn't load GitHub activity.
+      <button class="gh-retry" on:click={load}>Retry</button>
+    </div>
+  {:else}
+    <div class="gh-scroll">
+      <div class="gh-inner">
+        <div class="gh-months">
+          {#each monthLabels as m}
+            <span class="gh-month" style={`grid-column: ${m.index + 1}`}>{m.label}</span>
+          {/each}
+        </div>
+
+        <div
+          class="gh-cells"
+          on:mouseleave={() =>
+            (hovered = `${total.toLocaleString()} contributions in the last year`)}
+        >
+          {#each columns as col}
+            {#each col as day}
+              <div
+                class="gh-cell"
+                style={`background:${day ? levelVar(day.level) : "transparent"}`}
+                role="img"
+                aria-label={day ? pretty(day) : "No data"}
+                title={day ? pretty(day) : ""}
+                on:mouseenter={() => day && (hovered = pretty(day))}
+              ></div>
+            {/each}
+          {/each}
+        </div>
+      </div>
+    </div>
+
+    <div class="gh-footer">
+      <span class="gh-hint">{hovered}</span>
+      <span class="gh-legend">
+        Less
+        <i style="background: var(--github-activity-level0)"></i>
+        <i style="background: var(--github-activity-level1)"></i>
+        <i style="background: var(--github-activity-level4)"></i>
+        <i style="background: var(--github-activity-level8)"></i>
+        <i style="background: var(--github-activity-level12)"></i>
+        More
+      </span>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .gh {
+    width: 100%;
+  }
+
+  .gh-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    min-height: 90px;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+  }
+
+  .gh-retry {
+    border: 1px solid var(--border-color);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 0.75rem;
+    padding: 0.2rem 0.6rem;
+    cursor: pointer;
+  }
+
+  .gh-retry:hover {
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+  }
+
+  /* Mobile-first: fixed cells so the graph stays legible and scrolls sideways. */
+  .gh-scroll {
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 4px;
+    scrollbar-width: thin;
+  }
+
+  .gh-inner {
+    --cell: 11px;
+    --gap: 3px;
+    width: max-content;
+  }
+
+  .gh-months {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: var(--cell);
+    column-gap: var(--gap);
+    margin-bottom: 4px;
+    font-size: 10px;
+    color: var(--text-secondary);
+    overflow: hidden;
+  }
+
+  .gh-month {
+    white-space: nowrap;
+    line-height: 1;
+  }
+
+  .gh-cells {
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-rows: repeat(7, var(--cell));
+    grid-auto-columns: var(--cell);
+    gap: var(--gap);
+  }
+
+  .gh-cell {
+    width: var(--cell);
+    height: var(--cell);
+    border-radius: 2px;
+    outline: 1px solid transparent;
+    transition:
+      transform 0.15s ease,
+      outline-color 0.15s ease;
+  }
+
+  .gh-cell:hover {
+    transform: scale(1.35);
+    outline-color: var(--accent-primary);
+  }
+
+  .gh-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-top: 10px;
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+  }
+
+  .gh-hint {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .gh-legend {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    flex-shrink: 0;
+  }
+
+  .gh-legend i {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+  }
+
+  /* Larger screens: fill the card width instead of scrolling. */
+  @media (min-width: 640px) {
+    .gh-inner {
+      width: 100%;
+    }
+
+    .gh-months {
+      grid-auto-columns: 1fr;
+    }
+
+    .gh-cells {
+      grid-template-rows: repeat(7, 1fr);
+      grid-auto-columns: 1fr;
+      gap: clamp(2px, 0.45vw, 3px);
+    }
+
+    .gh-cell {
+      width: 100%;
+      height: auto;
+      aspect-ratio: 1 / 1;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .gh-legend {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/svelte/discord/DiscordActivity.svelte
+++ b/src/components/svelte/discord/DiscordActivity.svelte
@@ -231,8 +231,7 @@
 
 <style>
   .discord-activity {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
-      sans-serif;
+    font-family: inherit;
   }
 
   /* Fixed height container */

--- a/src/components/svelte/discord/ProfileDisplay.svelte
+++ b/src/components/svelte/discord/ProfileDisplay.svelte
@@ -55,10 +55,27 @@
         userData.discord_user.username,
       )
     : "Discord User";
+
+  // Presence status → readable label + color
+  const STATUS_LABEL: Record<string, string> = {
+    online: "Online",
+    idle: "Idle",
+    dnd: "Do Not Disturb",
+    offline: "Offline",
+  };
+  const STATUS_COLOR: Record<string, string> = {
+    online: "#43b581",
+    idle: "#faa61a",
+    dnd: "#f04747",
+    offline: "#747f8d",
+  };
+  $: status = userData?.discord_status ?? "offline";
+  $: statusLabel = STATUS_LABEL[status] ?? "Offline";
+  $: statusColor = STATUS_COLOR[status] ?? STATUS_COLOR.offline;
 </script>
 
 <div
-  class="profile-header p-4 flex flex-col justify-between"
+  class="profile-header p-4 flex flex-col gap-4"
   in:fade={{ duration: 300, delay: 100 }}
 >
   <div class="flex items-center w-full">
@@ -73,30 +90,36 @@
       {/if}
     </div>
     <div class="flex items-start justify-between w-full ml-4">
-      <div class="user-info flex-1">
-        <div class="flex flex-col">
+      <div class="user-info flex-1 min-w-0">
+        <div class="flex flex-col gap-0.5">
           <div
-            class="user-name font-semibold text-[var(--text-primary)] text-lg"
+            class="user-name font-semibold text-[var(--text-primary)] text-lg leading-tight truncate"
             in:slide={{ duration: 300, delay: 150 }}
           >
             {displayName}
           </div>
-          {#if userData?.discord_user?.discriminator && userData?.discord_user?.discriminator !== "0"}
-            <div
-              class="user-tag text-xs text-[var(--text-secondary)]"
-              in:slide={{ duration: 300, delay: 200 }}
-            >
-              {userData.discord_user.username}#{userData.discord_user
-                .discriminator}
-            </div>
-          {:else}
-            <div
-              class="user-tag text-xs text-[var(--text-secondary)]"
-              in:slide={{ duration: 300, delay: 200 }}
-            >
-              {userData?.discord_user?.username || ""}
-            </div>
-          {/if}
+          <div
+            class="status-line flex items-center gap-1.5"
+            in:slide={{ duration: 300, delay: 200 }}
+          >
+            <span
+              class="status-dot-inline"
+              style={`background:${statusColor}`}
+            ></span>
+            <span class="text-xs font-medium" style={`color:${statusColor}`}>
+              {statusLabel}
+            </span>
+            {#if userData?.discord_user?.discriminator && userData?.discord_user?.discriminator !== "0"}
+              <span class="text-xs text-[var(--text-secondary)] truncate">
+                · {userData.discord_user.username}#{userData.discord_user
+                  .discriminator}
+              </span>
+            {:else if userData?.discord_user?.username}
+              <span class="text-xs text-[var(--text-secondary)] truncate">
+                · {userData.discord_user.username}
+              </span>
+            {/if}
+          </div>
         </div>
       </div>
 
@@ -197,7 +220,6 @@
 
 <style>
   .profile-header {
-    min-height: 105px; /* Maintain consistent height for profile display */
     display: flex;
     flex-direction: column;
   }
@@ -210,6 +232,13 @@
     background-color: var(--bg-secondary);
   }
 
+  .status-dot-inline {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
   /* Discord buttons */
   .discord-button {
     padding: 6px 12px;
@@ -220,9 +249,7 @@
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;
-
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-      Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    font-family: inherit;
   }
 
   .discord-button:hover {

--- a/src/pages/socials.astro
+++ b/src/pages/socials.astro
@@ -6,14 +6,9 @@ import ThemeChanger from "../components/svelte/ThemeChanger.svelte";
 import { Image } from "astro:assets";
 import Pfp from "../assets/rohit.webp";
 import DiscordActivity from "../components/DiscordActivity.astro";
-import Mail from "../components/icons/Mail.astro";
-import Discord from "../components/icons/Discord.astro";
-import Instagram from "../components/icons/Instagram.astro";
-import Twitter from "../components/icons/Twitter.astro";
-import LinkedIn from "../components/icons/LinkedIn.astro";
-import GitHub from "../components/icons/GitHub.astro";
 import Favicon from "../components/icons/Favicon.astro";
 import SocialIcons from "../components/SocialIcons.astro";
+import SocialGithubGraph from "../components/svelte/SocialGithubGraph.svelte";
 import { PUBLIC_DIALOGH_URL } from "astro:env/client";
 
 const dialoghUrl = PUBLIC_DIALOGH_URL;
@@ -87,6 +82,29 @@ const pageUrl = Astro.site ? new URL("/socials", Astro.site).href : "/socials";
           >
         </Badge>
         <DiscordActivity showButtons={true} showAllActivities={true} />
+      </div>
+
+      <!-- GitHub Activity Section -->
+      <div
+        class="github-section links-section border border-[var(--border-color)] border-t-0 p-4 sm:p-6"
+      >
+        <div class="flex items-center gap-3 mb-4">
+          <Badge size="xs">
+            <span class="whitespace-nowrap text-xs uppercase"
+              >GitHub Activity</span
+            >
+          </Badge>
+          <div class="flex-1 h-px bg-[var(--border-color)]"></div>
+          <a
+            href={socials.github}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-xs uppercase text-[var(--text-secondary)] hover:text-[var(--accent-primary)] whitespace-nowrap"
+            >@DevRohit06 ↗</a
+          >
+        </div>
+
+        <SocialGithubGraph client:visible username="devrohit06" />
       </div>
 
       <!-- Portfolio Links Section -->
@@ -193,81 +211,6 @@ const pageUrl = Astro.site ? new URL("/socials", Astro.site).href : "/socials";
               </svg>
             </span>
             <span class="link-text">Download Resume</span>
-            <span class="link-arrow group-hover:translate-x-1">→</span>
-          </a>
-        </div>
-      </div>
-
-      <!-- Connect Links Section -->
-      <div
-        class="links-section border border-[var(--border-color)] border-t-0 p-4 sm:p-6"
-      >
-        <div class="flex items-center gap-3 mb-4">
-          <Badge size="xs">
-            <span class="whitespace-nowrap text-xs uppercase">Connect</span>
-          </Badge>
-          <div class="flex-1 h-px bg-[var(--border-color)]"></div>
-        </div>
-
-        <div class="flex flex-col gap-3">
-          <a
-            href={socials.github}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="link-button group"
-          >
-            <span class="link-icon"><GitHub /></span>
-            <span class="link-text">GitHub</span>
-            <span class="link-arrow group-hover:translate-x-1">→</span>
-          </a>
-
-          <a
-            href={socials.linkedIn}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="link-button group"
-          >
-            <span class="link-icon"><LinkedIn /></span>
-            <span class="link-text">LinkedIn</span>
-            <span class="link-arrow group-hover:translate-x-1">→</span>
-          </a>
-
-          <a
-            href={socials.twitter}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="link-button group"
-          >
-            <span class="link-icon"><Twitter /></span>
-            <span class="link-text">Twitter / X</span>
-            <span class="link-arrow group-hover:translate-x-1">→</span>
-          </a>
-
-          <a
-            href={socials.instagram}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="link-button group"
-          >
-            <span class="link-icon"><Instagram /></span>
-            <span class="link-text">Instagram</span>
-            <span class="link-arrow group-hover:translate-x-1">→</span>
-          </a>
-
-          <a
-            href={socials.discord}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="link-button group"
-          >
-            <span class="link-icon"><Discord /></span>
-            <span class="link-text">Discord</span>
-            <span class="link-arrow group-hover:translate-x-1">→</span>
-          </a>
-
-          <a href={socials.mail} class="link-button group">
-            <span class="link-icon"><Mail /></span>
-            <span class="link-text">Email Me</span>
             <span class="link-arrow group-hover:translate-x-1">→</span>
           </a>
         </div>

--- a/src/styles/discord.css
+++ b/src/styles/discord.css
@@ -1,7 +1,6 @@
 .discord-activity {
   min-height: 90px;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-family: inherit;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## Summary

Focused update to the `/socials` page and the shared Discord activity card.

### GitHub activity graph
- New `SocialGithubGraph.svelte` — a self-contained contribution graph on `/socials`.
- Fetches the public GitHub contributions API client-side (no token), so it works on the statically prerendered page.
- Colored with the existing `--github-activity-*` theme tokens (blue in light, warm in dark), with month labels, a hover readout, and a Less→More legend.
- Fills the card width on desktop; uses fixed, legible cells and scrolls horizontally on small screens.

### Socials cleanup
- Removed the **Connect** links section — it duplicated the social icons already in the profile card. Dropped the now-unused icon imports.

### Discord card polish (shared component)
- **Spacing:** replaced `justify-between` + a fixed `min-height` that pushed the "Powered by Lanyard" footer to the bottom, leaving a dead gap — now uses consistent spacing that sizes to content.
- **Font:** the card now inherits the site font (Roobert Mono) instead of the `-apple-system` stack.
- **Presence label:** added a readable status (Online / Idle / Do Not Disturb / Offline) with a matching colored dot next to the display name; the name truncates instead of overflowing.

> Note: the Discord changes touch the shared component, so they apply anywhere the Discord card is rendered.

## Testing
- `astro check` passes for all changed files (pre-existing errors elsewhere are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)