### PR TITLE
SEO & GEO improvements: canonical fix, FAQ/schema, mobile perf, input color

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,13 @@
+# ads.txt — Authorized Digital Sellers (IAB Tech Lab spec)
+# https://iabtechlab.com/ads-txt/
+#
+# This site (rohitk06.in) does not currently sell programmatic advertising,
+# so there are no authorized sellers to declare.
+#
+# When you onboard an ad network, add one line per authorized seller:
+#   <exchange-domain>, <publisher-account-id>, <DIRECT|RESELLER>, <certification-authority-id>
+#
+# Example (Google AdSense — replace with your real publisher ID before enabling):
+# google.com, pub-0000000000000000, DIRECT, f08c47fec0942fa0
+
+contact=https://www.rohitk06.in

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,23 @@
+# Rohit Kushwaha
+
+> Rohit Kushwaha is a full-stack engineer from Ambernath, India, focused on AI developer tooling. He builds end to end across Svelte, React, Next.js, Astro, Python, and Node.js, contributes to open-source AI-agent platforms, and creates developer tools such as discli and Lito.
+
+## About
+
+- [Portfolio home](https://www.rohitk06.in): Overview of Rohit Kushwaha, skills, experience, and featured work.
+- [Projects](https://www.rohitk06.in/projects): Things Rohit has built and shipped — AI developer tools, docs engines, and more.
+- [Blog](https://www.rohitk06.in/blog): Notes on what Rohit is learning, building, and thinking about.
+
+## Focus areas
+
+- Full-stack development (frontend + backend, end to end)
+- AI developer tooling and AI-agent platforms
+- Open-source contribution and personal developer tools (discli, Lito)
+- Stacks: Svelte / SvelteKit, React, Next.js, Astro, TypeScript, Python, Node.js
+
+## Links
+
+- [GitHub](https://github.com/DevRohit06)
+- [LinkedIn](https://www.linkedin.com/in/rohitk06/)
+- [X / Twitter](https://twitter.com/rohitk_06)
+- [Instagram](https://www.instagram.com/rohitk.06/)

--- a/src/components/Faq.astro
+++ b/src/components/Faq.astro
@@ -1,0 +1,122 @@
+---
+import Badge from "./Badge.astro";
+
+// Single source of truth: the visible FAQ and the FAQPage JSON-LD are both
+// generated from this array, so the structured data always matches the page
+// (a Google requirement for FAQ structured data). Answers are written
+// "answer-first" so AI answer engines can extract a clean, citable chunk.
+const faqs = [
+  {
+    q: "Who is Rohit Kushwaha?",
+    a: "Rohit Kushwaha is a full-stack engineer from Ambernath, Maharashtra, India, focused on AI developer tooling. He builds products end to end across Svelte, React, Next.js, Astro, Python, and Node.js, and is a core contributor to open-source AI-agent platforms.",
+  },
+  {
+    q: "What technologies and frameworks does Rohit work with?",
+    a: "Rohit works across the full stack: Svelte and SvelteKit, React, Next.js, and Astro on the frontend, with Python and Node.js on the backend, all in TypeScript. Most of his recent work is AI developer tooling — CLIs, agent platforms, and documentation engines.",
+  },
+  {
+    q: "What is Rohit's experience with AI developer tooling?",
+    a: "Rohit is a core contributor to the open-source AI-agent platform PocketPaw and has merged 180+ pull requests into open-source AI-agent projects. He also builds and maintains his own developer tools, including the CLI tool discli and Lito.",
+  },
+  {
+    q: "What open-source projects has Rohit contributed to?",
+    a: "Rohit is a core contributor to PocketPaw, added internationalization (i18n) to Astro's official documentation, and maintains his own open-source tools discli and Lito. His work spans AI-agent platforms, developer CLIs, and documentation engines.",
+  },
+  {
+    q: "Is Rohit available for freelance work or collaboration?",
+    a: "Yes. Rohit is open to freelance projects, collaborations, and interesting engineering problems. The fastest way to reach him is by email at rohitk290106@gmail.com, or through his GitHub, LinkedIn, or X profiles.",
+  },
+  {
+    q: "How can I contact Rohit Kushwaha?",
+    a: "You can email Rohit at rohitk290106@gmail.com, or connect on GitHub (DevRohit06), LinkedIn (in/rohitk06), and X/Twitter (@rohitk_06).",
+  },
+];
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map((item) => ({
+    "@type": "Question",
+    name: item.q,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: item.a,
+    },
+  })),
+};
+---
+
+<section class="faq-container relative" aria-labelledby="faq-heading">
+  <div
+    class="border border-[var(--border-color)] p-4 sm:p-6 md:p-12 relative faq-title-section"
+  >
+    <div class="size-4 bg-[var(--border-color)] absolute -top-2 -left-2"></div>
+    <Badge size="sm" className="mb-4">
+      <span class="text-xs font-bold uppercase">FAQ</span>
+    </Badge>
+
+    <h2
+      id="faq-heading"
+      class="text-3xl sm:text-4xl md:text-5xl font-semibold"
+    >
+      Frequently Asked Questions
+    </h2>
+  </div>
+
+  <div class="border border-[var(--border-color)] border-t-0">
+    {
+      faqs.map((item, index) => (
+        <details
+          class="faq-item group border-b border-[var(--border-color)] last:border-b-0"
+          name="faq"
+          open={index === 0}
+        >
+          <summary
+            class="flex items-center justify-between gap-4 cursor-pointer list-none px-4 sm:px-6 md:px-12 py-5 sm:py-6 text-base sm:text-lg md:text-xl font-medium select-none"
+          >
+            <span>{item.q}</span>
+            <span
+              class="faq-icon shrink-0 text-2xl leading-none text-[var(--accent-primary)] transition-transform duration-300 group-open:rotate-45"
+              aria-hidden="true"
+            >
+              +
+            </span>
+          </summary>
+          <p
+            class="px-4 sm:px-6 md:px-12 pb-5 sm:pb-6 -mt-1 text-sm sm:text-base md:text-lg text-[var(--text-secondary)]"
+          >
+            {item.a}
+          </p>
+        </details>
+      ))
+    }
+  </div>
+  <div class="size-4 bg-[var(--border-color)] absolute -bottom-2 -right-2 z-10">
+  </div>
+
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify(faqJsonLd)}
+  />
+</section>
+
+<style>
+  /* Remove the default disclosure triangle across browsers */
+  .faq-item summary::-webkit-details-marker {
+    display: none;
+  }
+  .faq-item summary::marker {
+    content: "";
+  }
+  .faq-item summary:hover {
+    background-color: color-mix(
+      in srgb,
+      var(--border-color) 18%,
+      transparent
+    );
+  }
+  .faq-item summary:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: -2px;
+  }
+</style>

--- a/src/components/HeroCard.astro
+++ b/src/components/HeroCard.astro
@@ -16,17 +16,17 @@ import SocialIcons from "./SocialIcons.astro";
       <h1
         class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-semibold hero-title split-text sm:pb-2"
       >
-        A Vibe Engineer*
+        Full-Stack Engineer
       </h1>
       <span
         class="text-sm sm:text-base md:text-lg text-[var(--text-secondary)] hero-subtitle"
-        >/ Software Engineer</span
+        >/ Vibe Engineer*</span
       >
     </div>
     <div
       class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-4 mt-4 sm:mt-6 hero-badges"
     >
-      <Badge size="lg" text="I believe in tech you use" />
+      <Badge size="lg" text="I build tech people actually use" />
       <Badge size="lg" text="Ambernath, India">
         <div
           class="animate-pulse bg-[var(--accent-primary)] size-2 rounded-full"
@@ -47,6 +47,7 @@ import SocialIcons from "./SocialIcons.astro";
             src={Pfp}
             loading="eager"
             decoding="async"
+            fetchpriority="high"
             alt="Rohit Kushwaha"
             class="object-cover w-full h-full aspect-square min-h-[20em] grayscale group-hover/hero:grayscale-0"
           />
@@ -70,10 +71,10 @@ import SocialIcons from "./SocialIcons.astro";
         </h2>
         <div class="bio-wrapper overflow-hidden mt-3 sm:mt-4">
           <p class="text-sm sm:text-base md:text-lg hero-bio leading-relaxed">
-            I'm a Full Stack Developer and vibe engineer who transforms ideas
-            into innovative, scalable solutions. With expertise in SvelteKit,
-            Astro, React, Next.js, and TailwindCSS, I craft pixel-perfect
-            interfaces with an intuitive feel.
+            I'm a full-stack engineer who ships end to end, from SvelteKit and
+            React interfaces to Python and Node backends. Lately I live in AI
+            developer tooling, contributing to open-source AI-agent platforms
+            and building my own tools like discli and Lito on the side.
           </p>
           <!-- <p class="text-sm sm:text-base md:text-lg mt-3 hero-bio-2">
             Currently pursuing a BSc in Computer Science at <a

--- a/src/components/OpenSource.astro
+++ b/src/components/OpenSource.astro
@@ -1,0 +1,383 @@
+---
+import TextReveal from "./TextReveal.astro";
+import Badge from "./Badge.astro";
+
+interface Props {
+  className?: string;
+}
+
+const { className = "" } = Astro.props;
+---
+
+<div class={`opensource-container relative ${className}`}>
+  <!-- Header -->
+  <div
+    class="border border-[var(--border-color)] p-4 sm:p-6 md:p-12 relative os-title-section os-anim"
+  >
+    <div class="size-4 bg-[var(--border-color)] absolute -top-2 -left-2"></div>
+    <Badge size="sm" className="mb-4">
+      <span class="text-xs font-bold uppercase">Open Source</span>
+    </Badge>
+
+    <TextReveal
+      element="h2"
+      text="Building in the open"
+      className="text-3xl sm:text-4xl md:text-5xl font-semibold os-title split-text"
+      splitBy="chars"
+      stagger={0.03}
+      from="bottom"
+    />
+
+    <p
+      class="text-sm sm:text-base md:text-lg text-[var(--text-secondary)] mt-4 max-w-2xl"
+    >
+      Most of what I build ships publicly. Here's where I contribute, maintain,
+      and occasionally break things in front of everyone.
+    </p>
+  </div>
+
+  <!-- Bento grid -->
+  <div class="os-bento border border-[var(--border-color)] border-t-0">
+    <!-- Flagship: PocketPaw -->
+    <a
+      href="https://github.com/pocketpaw/pocketpaw"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="os-tile os-tile--flagship group os-anim"
+      style="grid-area: pocket;"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <span class="os-role">Core Contributor</span>
+        <span class="os-stat os-stat--lg">866★</span>
+      </div>
+      <h3
+        class="text-2xl sm:text-3xl md:text-4xl font-semibold mt-4 group-hover:text-[var(--accent-primary)]"
+      >
+        PocketPaw
+      </h3>
+      <div class="os-bignum text-[var(--accent-primary)]">180+</div>
+      <div class="text-xs sm:text-sm text-[var(--text-secondary)] -mt-1 mb-4">
+        pull requests merged
+      </div>
+      <p
+        class="text-xs sm:text-sm md:text-base text-[var(--text-secondary)] leading-relaxed"
+      >
+        Self-hosted, open-source platform to spin up your own AI agent in
+        seconds. I'm one of the top contributors, shipping across site
+        deployment, the agent runtime, and cross-platform tooling.
+      </p>
+      <div class="flex flex-wrap gap-2 mt-auto pt-5">
+        {
+          ["Python", "AI Agents", "Cloudflare"].map((tag) => (
+            <span class="os-tag">{tag}</span>
+          ))
+        }
+      </div>
+    </a>
+
+    <!-- discli -->
+    <a
+      href="https://github.com/DevRohit06/discli"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="os-tile group os-anim"
+      style="grid-area: discli;"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <h3 class="text-lg sm:text-xl font-medium group-hover:text-[var(--accent-primary)]">
+          discli
+        </h3>
+        <span class="os-stat">23K+</span>
+      </div>
+      <p class="os-role mt-1">Creator &amp; Maintainer</p>
+      <p class="text-xs sm:text-sm text-[var(--text-secondary)] leading-relaxed mt-2">
+        A Discord CLI for AI agents and humans, with security profiles and audit
+        logging built in.
+      </p>
+      <div class="flex flex-wrap gap-2 mt-auto pt-4">
+        {["Python", "CLI", "PyPI"].map((tag) => <span class="os-tag">{tag}</span>)}
+      </div>
+    </a>
+
+    <!-- Lito -->
+    <a
+      href="https://github.com/Lito-docs/cli"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="os-tile group os-anim"
+      style="grid-area: lito;"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <h3 class="text-lg sm:text-xl font-medium group-hover:text-[var(--accent-primary)]">
+          Lito
+        </h3>
+        <span class="os-stat">npm</span>
+      </div>
+      <p class="os-role mt-1">Creator &amp; Maintainer</p>
+      <p class="text-xs sm:text-sm text-[var(--text-secondary)] leading-relaxed mt-2">
+        The open-source Mintlify alternative. A CLI-first docs engine that turns
+        Markdown into fast, searchable docs.
+      </p>
+      <div class="flex flex-wrap gap-2 mt-auto pt-4">
+        {["TypeScript", "Astro", "Docs"].map((tag) => <span class="os-tag">{tag}</span>)}
+      </div>
+    </a>
+
+    <!-- Astro Docs -->
+    <a
+      href="https://github.com/withastro/docs"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="os-tile group os-anim"
+      style="grid-area: astro;"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <h3 class="text-lg sm:text-xl font-medium group-hover:text-[var(--accent-primary)]">
+          Astro Docs
+        </h3>
+        <span class="os-stat">Merged</span>
+      </div>
+      <p class="os-role mt-1">i18n Contributor</p>
+      <p class="text-xs sm:text-sm text-[var(--text-secondary)] leading-relaxed mt-2">
+        Contributed Hindi internationalization to Astro's official
+        documentation.
+      </p>
+      <div class="flex flex-wrap gap-2 mt-auto pt-4">
+        {["Astro", "i18n", "Docs"].map((tag) => <span class="os-tag">{tag}</span>)}
+      </div>
+    </a>
+
+    <!-- CTA tile -->
+    <a
+      href="https://github.com/DevRohit06"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="os-tile os-tile--cta group os-anim"
+      style="grid-area: cta;"
+    >
+      <div>
+        <div class="text-2xl sm:text-3xl md:text-4xl font-semibold">
+          211 merged PRs
+        </div>
+        <div class="text-sm sm:text-base opacity-90 mt-1">and counting.</div>
+      </div>
+      <span
+        class="inline-flex items-center gap-2 mt-4 sm:mt-0 font-medium whitespace-nowrap group-hover:gap-3 transition-all"
+      >
+        See it all on GitHub
+        <span aria-hidden="true">→</span>
+      </span>
+    </a>
+  </div>
+
+  <div class="size-4 bg-[var(--border-color)] absolute -bottom-2 -right-2 z-10">
+  </div>
+</div>
+
+<style>
+  .opensource-container {
+    perspective: 1000px;
+  }
+
+  .os-title {
+    overflow: hidden;
+  }
+
+  /* Reveal: content is visible by default (no-JS safe). The pre-hidden state
+     is only applied by JS after IntersectionObserver support is confirmed. */
+  .os-anim {
+    transition:
+      opacity 0.6s ease,
+      transform 0.6s ease;
+  }
+
+  .os-anim.os-pre {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  .os-anim.os-in {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .os-anim,
+    .os-anim.os-pre {
+      opacity: 1 !important;
+      transform: none !important;
+      transition: none !important;
+    }
+  }
+
+  /* Bento grid: single column on mobile, asymmetric grid on md+ */
+  .os-bento {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "pocket"
+      "discli"
+      "lito"
+      "astro"
+      "cta";
+  }
+
+  @media (min-width: 768px) {
+    .os-bento {
+      grid-template-columns: repeat(3, 1fr);
+      grid-template-areas:
+        "pocket pocket discli"
+        "pocket pocket lito"
+        "astro  cta    cta";
+    }
+  }
+
+  .os-tile {
+    display: flex;
+    flex-direction: column;
+    padding: 1.25rem;
+    border-top: 1px solid var(--border-color);
+    background-color: var(--card-bg);
+    transition:
+      background-color 0.3s ease,
+      transform 0.3s ease;
+  }
+
+  @media (min-width: 768px) {
+    .os-tile {
+      padding: 1.5rem;
+      border-top: none;
+    }
+    /* Interior separators so tiles read as one grid */
+    .os-tile[style*="discli"],
+    .os-tile[style*="lito"],
+    .os-tile[style*="cta"] {
+      border-left: 1px solid var(--border-color);
+    }
+    .os-tile[style*="lito"],
+    .os-tile[style*="astro"],
+    .os-tile[style*="cta"] {
+      border-top: 1px solid var(--border-color);
+    }
+  }
+
+  .os-tile:hover {
+    transform: translateY(-2px);
+  }
+
+  .os-tile--flagship {
+    justify-content: flex-start;
+  }
+
+  .os-bignum {
+    font-size: clamp(2.75rem, 7vw, 4.5rem);
+    font-weight: 800;
+    line-height: 1;
+    margin-top: 0.75rem;
+  }
+
+  .os-role {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--accent-primary);
+  }
+
+  .os-stat {
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+    padding: 0.2rem 0.5rem;
+    white-space: nowrap;
+  }
+
+  .os-stat--lg {
+    font-size: 0.85rem;
+    color: var(--accent-primary);
+    border-color: var(--accent-primary);
+  }
+
+  .os-tag {
+    font-size: 0.7rem;
+    padding: 0.2rem 0.5rem;
+    background-color: var(--bg-secondary);
+    color: var(--text-secondary);
+    border-radius: 0.25rem;
+  }
+
+  /* CTA tile: accent-tinted, horizontal on desktop */
+  .os-tile--cta {
+    background-color: color-mix(in srgb, var(--accent-primary) 8%, var(--card-bg));
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+
+  @media (min-width: 640px) {
+    .os-tile--cta {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+  }
+
+  .os-tile--cta:hover {
+    background-color: color-mix(
+      in srgb,
+      var(--accent-primary) 16%,
+      var(--card-bg)
+    );
+  }
+</style>
+
+<script>
+  // Bulletproof reveal: independent of GSAP / ScrollTrigger / smooth-scroll.
+  // Content ships visible; JS only hides-then-reveals when IO is supported,
+  // so it can never get stuck invisible.
+  function initOpenSourceReveal() {
+    const items = Array.from(
+      document.querySelectorAll<HTMLElement>(".opensource-container .os-anim"),
+    );
+    if (!items.length) return;
+
+    const reduce = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    if (!("IntersectionObserver" in window) || reduce) {
+      items.forEach((el) => el.classList.add("os-in"));
+      return;
+    }
+
+    // Apply the pre-hidden state, then stagger reveal on scroll into view.
+    items.forEach((el, i) => {
+      el.classList.add("os-pre");
+      el.style.transitionDelay = `${Math.min(i * 70, 350)}ms`;
+    });
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const el = entry.target as HTMLElement;
+            el.classList.add("os-in");
+            io.unobserve(el);
+          }
+        });
+      },
+      { threshold: 0.15, rootMargin: "0px 0px -8% 0px" },
+    );
+
+    items.forEach((el) => io.observe(el));
+
+    // Safety net: if anything is still hidden after 2.5s, force it visible.
+    window.setTimeout(() => {
+      items.forEach((el) => {
+        if (!el.classList.contains("os-in")) el.classList.add("os-in");
+      });
+    }, 2500);
+  }
+
+  initOpenSourceReveal();
+  document.addEventListener("astro:page-load", initOpenSourceReveal);
+</script>

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -72,7 +72,7 @@ const defaultProps: SEOProps = {
       {
         name: "keywords",
         content:
-          "Rohit Kushwaha, AI Vibe Engineer, Vibe Engineering, AI Developer, Full Stack Developer, Artificial Intelligence, Human-AI Collaboration, React, Svelte, Node.js",
+          "Rohit Kushwaha, Rohit Kushwaha developer, Rohit Kushwaha engineer, Full-Stack Engineer, AI developer tooling, open source, PocketPaw, discli, Lito, Svelte, React, Next.js, Python, Node.js, Ambernath India",
       },
       // Add noindex tag for pages that should be excluded from search engines
       ...(props.noindex
@@ -84,14 +84,33 @@ const defaultProps: SEOProps = {
       ...(props.extend?.meta || []),
     ],
     link: [
-      // Add the canonical link as a rel="canonical" tag
-      { rel: "canonical", href: canonicalUrl },
+      // Canonical is emitted by astro-seo via the `canonical` prop above.
+      // Do NOT add a second rel="canonical" here or pages get duplicate tags.
       ...(props.extend?.link || []),
     ],
   },
 };
 
 const combinedProps = { ...defaultProps, ...props };
+
+// Build BreadcrumbList structured data for non-home pages.
+// Helps search engines and AI answer engines understand the site hierarchy.
+const pathSegments = Astro.url.pathname.split("/").filter(Boolean);
+const breadcrumbList = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: baseUrl },
+    ...pathSegments.map((segment, index) => ({
+      "@type": "ListItem",
+      position: index + 2,
+      name: decodeURIComponent(segment)
+        .replace(/-/g, " ")
+        .replace(/\b\w/g, (c) => c.toUpperCase()),
+      item: getCanonicalUrl("/" + pathSegments.slice(0, index + 1).join("/")),
+    })),
+  ],
+};
 ---
 
 <AstroSEO {...combinedProps} />
@@ -103,22 +122,42 @@ const combinedProps = { ...defaultProps, ...props };
     "@context": "https://schema.org",
     "@type": "Person",
     name: "Rohit Kushwaha",
+    alternateName: "Rohit Kushwaha (DevRohit06)",
     url: baseUrl,
     image: `${baseUrl}/images/rohit.webp`,
-    jobTitle: "AI Vibe Engineer & Full Stack Developer",
+    jobTitle: "Full-Stack Engineer",
+    worksFor: {
+      "@type": "Organization",
+      name: "Qbtrix",
+      url: "https://qbtrix.com",
+    },
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Ambernath",
+      addressRegion: "Maharashtra",
+      addressCountry: "India",
+    },
+    nationality: "Indian",
     sameAs: [
-      "https://github.com/devrohit06",
-      "https://linkedin.com/in/rohitk06",
+      "https://github.com/DevRohit06",
+      "https://www.linkedin.com/in/rohitk06/",
       "https://twitter.com/rohitk_06",
+      "https://www.instagram.com/rohitk.06/",
     ],
     description:
-      "AI Vibe Engineer specializing in creating intelligent digital experiences through human-AI collaboration and modern web technologies.",
+      "Rohit Kushwaha is a full-stack engineer from Ambernath, India, focused on AI developer tooling. He is a core contributor to the open-source AI-agent platform PocketPaw and the creator of developer tools including discli and Lito, building end to end across Svelte, React, Next.js, Python, and Node.js.",
     knowsAbout: [
-      "Artificial Intelligence",
-      "Web Development",
-      "Human-AI Collaboration",
-      "User Experience Design",
-      "Vibe Engineering",
+      "Full-Stack Development",
+      "AI Developer Tooling",
+      "Svelte",
+      "SvelteKit",
+      "React",
+      "Next.js",
+      "Astro",
+      "TypeScript",
+      "Python",
+      "Node.js",
+      "Open Source",
     ],
   })}
 />
@@ -133,11 +172,21 @@ const combinedProps = { ...defaultProps, ...props };
     name: mainMetaData.title,
     description: mainMetaData.description,
     keywords:
-      "AI Vibe Engineer, Rohit Kushwaha, Artificial Intelligence, Human-AI Collaboration",
+      "Rohit Kushwaha, Full-Stack Engineer, AI developer tooling, open source, Svelte, React, Next.js, Python",
     author: {
       "@type": "Person",
       name: "Rohit Kushwaha",
-      jobTitle: "AI Vibe Engineer",
+      jobTitle: "Full-Stack Engineer",
     },
   })}
 />
+
+<!-- BreadcrumbList structured data (only for pages below the homepage) -->
+{
+  pathSegments.length > 0 && (
+    <script
+      type="application/ld+json"
+      set:html={JSON.stringify(breadcrumbList)}
+    />
+  )
+}

--- a/src/components/svelte/ContactForm.svelte
+++ b/src/components/svelte/ContactForm.svelte
@@ -259,7 +259,7 @@
   input,
   textarea {
     padding: 0.75rem 1rem;
-    background-color: var(--bg-primary);
+    background-color: var(--input-bg);
     border: 1px solid var(--border-color);
     color: var(--text-primary);
     font-family: inherit;

--- a/src/components/svelte/ExperienceToggler.svelte
+++ b/src/components/svelte/ExperienceToggler.svelte
@@ -8,12 +8,12 @@
   let experiences = [
     {
       id: 1,
-      title: "Fullstack Dev",
-      role: "Fullstack Developer",
+      title: "Full-Stack Engineer",
+      role: "Full-Stack Engineer",
       company: "Qbtrix",
       duration: "DEC 2024 -  PRESENT",
       description:
-        "I'm currently creating cool stuff at Qbtrix! Every day brings new challenges that push my skills to the next level. I love how each project teaches me something new about building intuitive digital experiences.",
+        "I own frontend across several of Qbtrix's products, building most of the UI and the state management behind it, while also working on AI agents and internal tooling. That includes our ripple-iui framework (per-widget binding contracts, composite layouts, live spec sync) and soul-protocol, an open standard for portable AI identity.",
       isActive: true,
       links: [
         { id: 1, title: "Qbtrix", url: "https://qbtrix.com" },
@@ -22,12 +22,12 @@
     },
     {
       id: 2,
-      title: "Fullstack Dev",
-      role: "Fullstack Developer Intern",
+      title: "Full-Stack Developer Intern",
+      role: "Full-Stack Developer Intern",
       company: "Qbtrix",
       duration: "DEC 2023 -  DEC 2024",
       description:
-        "This was where I really found my groove! I built the entire frontend for Interacly.com (check it out!) and got to play with tons of exciting tech. Learned so much about how real teams ship amazing products together.",
+        "Where I found my groove on a real product team. I built out the frontend for Interacly and worked across the stack shipping features into production, learning how teams actually design, review, and ship software at scale.",
       isActive: false,
       links: [
         { id: 1, title: "Qbtrix", url: "https://qbtrix.com" },
@@ -41,7 +41,7 @@
       company: "Freelance",
       duration: "2020 - 2023",
       description:
-        "My first steps into the coding world! Started with the basics - HTML, CSS, and JavaScript - building small websites for local businesses. Every project was both terrifying and thrilling, but that's how I caught the development bug!",
+        "My first steps into the industry, building websites for local businesses with HTML, CSS, and JavaScript. Every project was equal parts terrifying and thrilling, and that's exactly how I caught the development bug that led here.",
       isActive: false,
     },
   ];
@@ -185,6 +185,33 @@
         </div>
       {/key}
     </div>
+  </div>
+
+  <!--
+    SEO / LLM fallback. The interactive panel above only mounts the ACTIVE
+    experience (via {#key}), so non-active roles never reach the server-rendered
+    HTML. This visually-hidden list renders every role from the same
+    `experiences` array (single source of truth), guaranteeing all work history
+    is crawlable without JavaScript.
+  -->
+  <div class="sr-only">
+    <h2>Work Experience</h2>
+    <ul>
+      {#each experiences as experience (experience.id)}
+        <li>
+          <h3>{experience.title} — {experience.company}</h3>
+          <p>{experience.duration}</p>
+          <p>{experience.description}</p>
+          {#if experience.links}
+            <ul>
+              {#each experience.links as link (link.id)}
+                <li><a href={link.url}>{link.title}</a></li>
+              {/each}
+            </ul>
+          {/if}
+        </li>
+      {/each}
+    </ul>
   </div>
 </div>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -88,7 +88,9 @@ const googleTagKey = PUBLIC_GOOGLE_TAG_KEY;
       }}
       extend={{
         link: [
-          { rel: "canonical", href: canonicalURL },
+          // Canonical is emitted once by <Seo> via astro-seo's `canonical` prop.
+          // Adding it here caused duplicate <link rel="canonical"> tags (one with
+          // a trailing slash, one without) — do not re-add it.
           {
             rel: "alternate",
             type: "application/rss+xml",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -51,11 +51,24 @@ const googleTagKey = PUBLIC_GOOGLE_TAG_KEY;
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="sitemap" href="/sitemap-index.xml" />
+
+    <!-- Preload above-the-fold fonts to cut LCP: Regular (body) + SemiBold (hero title) -->
+    <link
+      rel="preload"
+      href="/fonts/RoobertTRIAL-Regular.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="/fonts/RoobertTRIAL-SemiBold.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
 
 
     <!-- Theme initialization script - runs before anything renders -->
@@ -120,8 +133,6 @@ const googleTagKey = PUBLIC_GOOGLE_TAG_KEY;
       }}
     />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="generator" content={Astro.generator} />
     

--- a/src/lib/metaData.ts
+++ b/src/lib/metaData.ts
@@ -35,16 +35,16 @@ type MetaData = z.output<typeof metaDataSchema>;
 type MetaDataInput = z.input<typeof metaDataSchema>;
 
 const _mainMetaData: MetaDataInput = {
-  title: "Hey, I'm Rohit Kushwaha | AI Enthusiast & Creative Developer",
+  title: "Hey, I'm Rohit Kushwaha | Full-Stack & AI Tooling Engineer",
   description:
-    "Hi there! I'm Rohit, crafting digital vibes with AI and modern tech.{n}I build smart, intuitive experiences that merge AI with React, Svelte, and Node.js.{nMd}When I'm not coding, I'm exploring how human creativity and artificial intelligence can create something amazing together.",
+    "I'm Rohit, a full-stack engineer who ships end to end.{n}Svelte and React on the front, Python and Node on the back, and a lot of AI developer tooling in between.{nMd}I contribute to open-source AI-agent platforms and build my own tools like discli and Lito.",
 };
 export const mainMetaData = metaDataSchema.parse(_mainMetaData);
 
 const _projectMetaData: MetaDataInput = {
-  title: "Cool stuff I've built{n}along the way",
+  title: "Things I've built{n}and shipped",
   description:
-    "Every project here tells a story about a problem I wanted to solve.{nMd}Dig in to see how I've tackled interesting challenges and what I've learned from them!",
+    "Every project here started as a problem I wanted to solve, from AI dev tools to docs engines.{nMd}Dig in to see how I approached each one and what I learned along the way.",
 };
 export const projectMetaData: MetaData = metaDataSchema.parse(_projectMetaData);
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,6 +15,8 @@ import LiveClock from "../components/svelte/LiveClock.svelte";
 import AboutMe from "../components/AboutMe.astro";
 import Projects from "../components/Projects.astro";
 import Skills from "../components/Skills.astro";
+import OpenSource from "../components/OpenSource.astro";
+import Faq from "../components/Faq.astro";
 import ContactSection from "../components/ContactSection.astro";
 
 // Set showLoader to true only for the first visit in a session
@@ -22,57 +24,63 @@ import ContactSection from "../components/ContactSection.astro";
 const showLoader = true;
 
 // SEO metadata for the homepage
-const pageTitle = "Rohit Kushwaha - Software Engineer Portfolio";
+// ~59 chars — within Google's recommended 50–60 char title length.
+const pageTitle = "Rohit Kushwaha — Full-Stack Engineer & AI Tooling Developer";
 const description =
-  "Portfolio of Rohit Kushwaha, a software engineer specializing in web development, React, Next.js, Svelte, and modern JavaScript frameworks.";
+  "Portfolio of Rohit Kushwaha, a full-stack engineer building AI developer tooling and web apps with Svelte, React, Next.js, Python, and Node.js. 180+ merged PRs into open-source AI-agent platforms.";
 const canonicalURL = new URL("/", Astro.site || Astro.url.origin).href;
 const keywords = [
-  "software engineer",
-  "web developer",
-  "portfolio",
   "Rohit Kushwaha",
+  "Rohit Kushwaha portfolio",
+  "Rohit Kushwaha developer",
+  "full-stack engineer",
+  "AI developer tooling",
+  "open source",
+  "PocketPaw",
+  "discli",
   "React",
   "Next.js",
   "Svelte",
-  "JavaScript",
+  "Python",
 ];
 
 // Structured data for search engines
 const jsonLd = {
   "@context": "https://schema.org",
   "@type": "ProfilePage",
-  headline: "Rohit Kushwaha - Software Engineer Portfolio",
+  headline: "Rohit Kushwaha - Full-Stack Engineer",
   datePublished: "2025-05-08",
   dateModified: new Date().toISOString(),
   description: description,
   author: {
     "@type": "Person",
     name: "Rohit Kushwaha",
-    jobTitle: "Software Engineer",
+    jobTitle: "Full-Stack Engineer",
     url: Astro.site?.toString() || "https://rohitk06.in",
     sameAs: [
-      "https://github.com/devrohit06",
-      "https://linkedin.com/in/rohitk06",
+      "https://github.com/DevRohit06",
+      "https://www.linkedin.com/in/rohitk06/",
       "https://twitter.com/rohitk_06",
-      "https://instagram.com/rohitk.06",
+      "https://www.instagram.com/rohitk.06/",
     ],
   },
   mainEntity: {
     "@type": "Person",
     name: "Rohit Kushwaha",
-    jobTitle: "Software Engineer",
+    jobTitle: "Full-Stack Engineer",
+    description:
+      "Rohit Kushwaha is a full-stack engineer from Ambernath, India, and a core contributor to the open-source AI-agent platform PocketPaw. He builds AI developer tooling such as discli and Lito across Svelte, React, Next.js, Python, and Node.js.",
     alumniOf: "SMT. CHM College, Ulhasnagar",
     knowsAbout: [
-      "svelte",
-      "sveltekit",
-      "astro",
-      "ai",
-      "Web Development",
-      "JavaScript",
-      "React",
+      "Full-Stack Development",
+      "AI Developer Tooling",
       "Svelte",
+      "SvelteKit",
+      "Astro",
+      "React",
       "Next.js",
       "Node.js",
+      "Python",
       "TypeScript",
     ],
   },
@@ -227,10 +235,26 @@ const jsonLd = {
     </div>
     <!-- End Projects Section -->
 
+    <!-- Open Source Section -->
+    <div
+      class="w-[95%] xs:w-[90%] sm:w-[85%] md:w-[80%] lg:w-[75%] xl:w-[70%] 2xl:w-[65%] mx-auto mb-40 md:mb-56 lg:mb-64"
+    >
+      <OpenSource />
+    </div>
+    <!-- End Open Source Section -->
+
     <!-- Blog Section with increased spacing -->
     <div class="mb-40 md:mb-48 lg:mb-56">
       <BlogSection />
     </div>
+
+    <!-- FAQ Section -->
+    <div
+      class="w-[95%] xs:w-[90%] sm:w-[85%] md:w-[80%] lg:w-[75%] xl:w-[70%] 2xl:w-[65%] mx-auto mb-40 md:mb-56 lg:mb-64"
+    >
+      <Faq />
+    </div>
+    <!-- End FAQ Section -->
 
     <!-- Contact Section -->
     <div

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -8,18 +8,28 @@ export async function GET({ site }: APIContext) {
 User-agent: *
 Allow: /
 
-# Important pages that should be prioritized
-Allow: /index.html
-Allow: /about
-Allow: /projects
-Allow: /blogs
-Allow: /socials
+# AI / LLM crawlers — explicitly welcomed for GEO/AEO visibility
+# (ChatGPT, Claude, Perplexity, and Google's AI training/answer bots)
+User-agent: GPTBot
+Allow: /
 
-# Slightly less important content - still allow but with lower priority
-Allow: /images/
+User-agent: OAI-SearchBot
+Allow: /
 
-# Optimize crawling rate
-Crawl-delay: 5
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
 
 # Sitemaps
 Sitemap: ${siteUrl}sitemap-index.xml

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,6 +58,9 @@
   --accent-secondary: #000088;
   --border-color: #7b7b7b;
   --card-bg: #c9cdd1;
+  /* Soft off-white for form fields — avoids the harsh pure-white glare
+     against the muted #c9cdd1 page background in light mode. */
+  --input-bg: #eef0f2;
   --code-bg: rgba(123, 123, 123, 0.1);
   --blockquote-bg: rgba(7, 7, 172, 0.05);
   --progress-bar-bg: #0707ac;
@@ -86,6 +89,8 @@
   --accent-secondary: #a0a0a0;
   --border-color: #555555;
   --card-bg: #202020;
+  /* Dark mode already looked fine — keep the prior input surface. */
+  --input-bg: #121212;
   --code-bg: rgba(123, 123, 123, 0.2);
   --blockquote-bg: rgba(123, 123, 123, 0.1);
   --progress-bar-bg: #ff5533;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,18 +2,21 @@
   font-family: "Roobert Mono";
   src: url("/fonts/RoobertTRIAL-Regular.woff2") format("woff2");
   font-weight: normal;
+  font-display: swap;
 }
 
 @font-face {
   font-family: "Roobert Mono";
   src: url("/fonts/RoobertTRIAL-Bold.woff2") format("woff2");
   font-weight: bold;
+  font-display: swap;
 }
 
 @font-face {
   font-family: "Roobert Mono";
   src: url("/fonts/RoobertTRIAL-SemiBold.woff2") format("woff2");
   font-weight: 600;
+  font-display: swap;
 }
 
 @import "tailwindcss";


### PR DESCRIPTION
## Summary

SEO, GEO (generative-engine optimization), and mobile-performance improvements, driven by an SEOptimer audit of the live site plus 2026 best-practice research. Also fixes a light-mode input color issue.

### On-page SEO
- **Fix duplicate canonical tag** — the site emitted two `<link rel=canonical>` (one with a trailing slash, one without). Root cause was `Layout.astro` re-adding a canonical on top of astro-seo's `canonical` prop. Now exactly one canonical is emitted (verified in built HTML).
- **Homepage `<title>` length** — extended from ~36 to ~59 chars (Google's 50–60 target).

### GEO / AEO (AI search)
- **FAQ section + `FAQPage` JSON-LD** — new `Faq.astro`, rendered as static `<details>` HTML (works with JS disabled) so answer engines can extract citable chunks.
- **`BreadcrumbList` structured data** on non-home pages.
- **`robots.txt`** — dropped `Crawl-delay`, explicitly allow AI crawlers (GPTBot, ClaudeBot, PerplexityBot, OAI-SearchBot, Google-Extended).
- **`public/llms.txt`** and **`public/ads.txt`** added.
- **Experience crawlability** — `ExperienceToggler` only server-rendered the active role; added an `sr-only` fallback so all roles are in static HTML. Crawlable homepage text went 863 → ~1,541 words (also resolves the "thin content" flag).

### Mobile performance (LCP / INP)
- `font-display: swap` on all `@font-face` (was up to 3s of invisible text).
- Preload above-the-fold Regular + SemiBold font weights; removed dead Google Fonts preconnects (no Google Fonts stylesheet was ever loaded).
- `fetchpriority="high"` on the hero image (mobile LCP candidate).
- Restored pinch-zoom in the viewport meta (accessibility).

### UI fix
- Softened form input background in light mode via a new `--input-bg` token (`#eef0f2` light / `#121212` dark) — was pure white and glared against the muted page.

## Verification
- `astro build` passes; verified in built HTML: single canonical, 59-char title, FAQPage/BreadcrumbList JSON-LD present, all experience descriptions crawlable, font preloads + `fetchpriority` + `font-display:swap` applied.

## Not included
- Unrelated in-progress edits to `AboutMe.astro` and `Skills.astro` were intentionally left out of this branch.

## Follow-ups (infra, not code)
- The ~1.1s "avoid multiple redirects" on mobile is a Vercel/DNS redirect chain (apex → www → https). Collapse to a single hop in Vercel domain settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)