### PR TITLE
feat(api): publish RFC 9727 API catalog for agent discovery

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -110,6 +110,14 @@ const googleTagKey = PUBLIC_GOOGLE_TAG_KEY;
             href: "/rss.xml",
             title: "Rohit Kushwaha's Blog RSS Feed",
           },
+          // RFC 9727: advertise the API catalog so agents can find it from any
+          // page, not only by probing the well-known URI.
+          {
+            rel: "api-catalog",
+            type: "application/linkset+json",
+            href: "/.well-known/api-catalog",
+            title: "API catalog",
+          },
         ],
         meta: [
           { name: "author", content: "Rohit Kushwaha" },

--- a/src/lib/apiCatalog.ts
+++ b/src/lib/apiCatalog.ts
@@ -1,0 +1,410 @@
+/**
+ * Single source of truth for the public HTTP API surface of this site.
+ *
+ * Three routes are generated from this list and must stay in sync:
+ *   - /.well-known/api-catalog — RFC 9727 linkset, for machine discovery
+ *   - /openapi.json            — OpenAPI 3.1 description (the `service-desc` target)
+ *   - /api-docs                — human documentation (the `service-doc` target)
+ *
+ * `/api/github/last-updated-file` is deliberately absent: it queries an
+ * unrelated upstream repository and is not part of this site's public API.
+ */
+
+export const SITE_FALLBACK = "https://rohitk06.in";
+
+/** Absolute URL for a site-relative path, without a duplicated slash. */
+export function absoluteUrl(path: string, site?: URL): string {
+  const origin = (site?.toString() ?? SITE_FALLBACK).replace(/\/$/, "");
+  return `${origin}${path}`;
+}
+
+export interface ApiParameter {
+  name: string;
+  in: "path" | "query";
+  required: boolean;
+  description: string;
+  example: string;
+}
+
+export interface ApiResponse {
+  status: string;
+  description: string;
+  /** JSON Schema for the response body, inlined into the OpenAPI document. */
+  schema?: Record<string, unknown>;
+}
+
+export interface ApiOperation {
+  method: "get" | "post";
+  /** OpenAPI-style path with `{braced}` template variables. */
+  path: string;
+  operationId: string;
+  summary: string;
+  description: string;
+  parameters?: ApiParameter[];
+  requestBody?: {
+    description: string;
+    schema: Record<string, unknown>;
+  };
+  responses: ApiResponse[];
+}
+
+export interface CatalogedApi {
+  /** Stable slug — used as the docs fragment and the OpenAPI tag. */
+  id: string;
+  name: string;
+  description: string;
+  /**
+   * Path that identifies the API itself. Becomes the `anchor` of the API's
+   * entry in the RFC 9727 linkset, so it must be stable across releases.
+   */
+  anchorPath: string;
+  operations: ApiOperation[];
+}
+
+const contributionDaySchema = {
+  type: "object",
+  properties: {
+    count: { type: "integer", description: "Contributions recorded that day." },
+    date: {
+      type: "string",
+      description: "Date of the contributions, formatted `YYYY/MM/DD`.",
+      example: "2026/08/13",
+    },
+  },
+  required: ["count", "date"],
+} as const;
+
+const contributionsSchema = {
+  type: "object",
+  properties: {
+    lastPushedAt: {
+      type: "string",
+      format: "date-time",
+      description: "Timestamp of the most recent push to any owned repository.",
+    },
+    totalContributions: {
+      type: "integer",
+      description: "Total contributions over the trailing twelve months.",
+    },
+    contributions: {
+      type: "array",
+      description: "One entry per day of the trailing twelve months.",
+      items: contributionDaySchema,
+    },
+  },
+  required: ["lastPushedAt", "totalContributions", "contributions"],
+} as const;
+
+const repoInfoSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    name: { type: "string" },
+    nameWithOwner: { type: "string" },
+    description: { type: "string", nullable: true },
+    forkCount: { type: "integer" },
+    stargazerCount: { type: "integer" },
+    openGraphImageUrl: { type: "string", format: "uri" },
+    pushedAt: { type: "string", format: "date-time" },
+    updatedAt: { type: "string", format: "date-time" },
+    url: { type: "string", format: "uri" },
+  },
+  required: ["name", "nameWithOwner", "forkCount", "stargazerCount", "url"],
+} as const;
+
+const linkMetadataSchema = {
+  type: "object",
+  properties: {
+    success: {
+      type: "boolean",
+      description: "`false` when the target could not be scraped; no other fields are then present.",
+    },
+    title: { type: "string" },
+    description: { type: "string" },
+    faviconUrl: { type: "string", format: "uri" },
+    requestUrl: { type: "string", format: "uri" },
+    image: {
+      type: "object",
+      properties: {
+        url: { type: "string", format: "uri" },
+        alt: { type: "string" },
+        width: { type: "integer" },
+        height: { type: "integer" },
+      },
+      required: ["url"],
+    },
+  },
+  required: ["success"],
+} as const;
+
+const errorSchema = {
+  type: "object",
+  properties: { error: { type: "string" } },
+  required: ["error"],
+} as const;
+
+export const apis: CatalogedApi[] = [
+  {
+    id: "github-insights",
+    name: "GitHub Insights API",
+    description:
+      "Read-only GitHub activity for the site owner: the contribution calendar for the trailing twelve months, and metadata for a named public repository.",
+    anchorPath: "/api/github",
+    operations: [
+      {
+        method: "get",
+        path: "/api/github/contributions",
+        operationId: "getGithubContributions",
+        summary: "Contribution calendar",
+        description:
+          "Daily GitHub contribution counts for the trailing twelve months, plus the timestamp of the most recent push. Cached at the edge for one hour.",
+        responses: [
+          {
+            status: "200",
+            description: "The contribution calendar.",
+            schema: contributionsSchema,
+          },
+        ],
+      },
+      {
+        method: "get",
+        path: "/api/github/repo-info/{owner}/{repository}",
+        operationId: "getRepoInfo",
+        summary: "Public repository metadata",
+        description:
+          "Name, description, star and fork counts, and last-push time for a public GitHub repository. Cached at the edge for one hour.",
+        parameters: [
+          {
+            name: "owner",
+            in: "path",
+            required: true,
+            description: "GitHub account that owns the repository.",
+            example: "DevRohit06",
+          },
+          {
+            name: "repository",
+            in: "path",
+            required: true,
+            description: "Repository name.",
+            example: "portfolio",
+          },
+        ],
+        responses: [
+          {
+            status: "200",
+            description: "Repository metadata.",
+            schema: repoInfoSchema,
+          },
+          {
+            status: "500",
+            description: "The upstream GitHub request failed.",
+            schema: errorSchema,
+          },
+        ],
+      },
+      {
+        method: "get",
+        path: "/api/github-contributions",
+        operationId: "getGithubContributionsAlias",
+        summary: "Contribution calendar (standalone alias)",
+        description:
+          "Returns the same payload as `/api/github/contributions`. Kept as a separate route for existing callers; prefer the namespaced path in new code.",
+        responses: [
+          {
+            status: "200",
+            description: "The contribution calendar.",
+            schema: contributionsSchema,
+          },
+          {
+            status: "500",
+            description: "The upstream GitHub request failed.",
+            schema: errorSchema,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "link-metadata",
+    name: "Link Metadata API",
+    description:
+      "Resolves a URL to its Open Graph and Twitter card metadata — title, description, favicon, and preview image — for rendering link previews.",
+    anchorPath: "/api/link-metadata",
+    operations: [
+      {
+        method: "get",
+        path: "/api/link-metadata",
+        operationId: "getLinkMetadata",
+        summary: "Scrape link preview metadata",
+        description:
+          "Fetches the target URL and extracts its Open Graph / Twitter card metadata. Twitter values win over Open Graph values when both are present.",
+        parameters: [
+          {
+            name: "url",
+            in: "query",
+            required: true,
+            description: "Absolute URL to scrape.",
+            example: "https://astro.build",
+          },
+        ],
+        responses: [
+          {
+            status: "200",
+            description:
+              "Metadata for the target. `success` is `false` when the page could not be scraped.",
+            schema: linkMetadataSchema,
+          },
+          {
+            status: "400",
+            description: "The `url` query parameter is missing or malformed.",
+            schema: errorSchema,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "project-repo",
+    name: "Project Repository API",
+    description:
+      "Everything the project pages need about a public GitHub repository in one request: REST metadata, the rendered README source, and the language breakdown.",
+    anchorPath: "/api/project-repo",
+    operations: [
+      {
+        method: "get",
+        path: "/api/project-repo/{owner}/{repo}",
+        operationId: "getProjectRepo",
+        summary: "Repository metadata, README, and languages",
+        description:
+          "Combines three GitHub REST calls into one response. `readmeContent` and `languages` are `null` when the corresponding upstream call fails; only a failed metadata call produces an error status. Cached for one hour.",
+        parameters: [
+          {
+            name: "owner",
+            in: "path",
+            required: true,
+            description: "GitHub account that owns the repository.",
+            example: "DevRohit06",
+          },
+          {
+            name: "repo",
+            in: "path",
+            required: true,
+            description: "Repository name.",
+            example: "portfolio",
+          },
+        ],
+        responses: [
+          {
+            status: "200",
+            description: "Repository payload.",
+            schema: {
+              type: "object",
+              properties: {
+                repoInfo: {
+                  type: "object",
+                  description: "Raw GitHub REST repository object.",
+                  additionalProperties: true,
+                },
+                readmeContent: {
+                  type: "string",
+                  nullable: true,
+                  description: "Raw README markdown, or `null` if unavailable.",
+                },
+                languages: {
+                  type: "object",
+                  nullable: true,
+                  description: "Language name to bytes-of-code, or `null` if unavailable.",
+                  additionalProperties: { type: "integer" },
+                },
+              },
+              required: ["repoInfo"],
+            },
+          },
+          {
+            status: "400",
+            description: "`owner` or `repo` is missing.",
+            schema: errorSchema,
+          },
+          {
+            status: "500",
+            description: "The upstream GitHub request failed.",
+            schema: errorSchema,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "contact",
+    name: "Contact API",
+    description:
+      "Delivers a message from the site's contact form to the owner's inbox. Every request must carry a valid Cloudflare Turnstile token.",
+    anchorPath: "/api/contact",
+    operations: [
+      {
+        method: "post",
+        path: "/api/contact",
+        operationId: "submitContactMessage",
+        summary: "Send a contact message",
+        description:
+          "Validates the payload, verifies the Turnstile token against Cloudflare, then sends the message by email. Intended for the site's own contact form.",
+        requestBody: {
+          description: "The message and its Turnstile proof-of-humanity token.",
+          schema: {
+            type: "object",
+            properties: {
+              name: { type: "string", description: "Sender's name." },
+              email: {
+                type: "string",
+                format: "email",
+                description: "Sender's email address; used as the reply-to.",
+              },
+              subject: { type: "string", description: "Message subject." },
+              message: { type: "string", description: "Message body." },
+              turnstileToken: {
+                type: "string",
+                description: "Token issued by the Cloudflare Turnstile widget.",
+              },
+            },
+            required: ["name", "email", "subject", "message", "turnstileToken"],
+          },
+        },
+        responses: [
+          {
+            status: "200",
+            description: "The message was accepted and sent.",
+            schema: {
+              type: "object",
+              properties: {
+                success: { type: "boolean" },
+                message: { type: "string" },
+              },
+              required: ["success", "message"],
+            },
+          },
+          {
+            status: "400",
+            description:
+              "A required field is missing, the email is malformed, or Turnstile verification failed.",
+            schema: errorSchema,
+          },
+          {
+            status: "500",
+            description: "The message could not be delivered.",
+            schema: errorSchema,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+/** Path of the shared health endpoint, the `status` target for every API. */
+export const HEALTH_PATH = "/api/health";
+
+/** Media type of the health endpoint, per draft-inadarei-api-health-check. */
+export const HEALTH_MEDIA_TYPE = "application/health+json";
+
+export const OPENAPI_PATH = "/openapi.json";
+export const DOCS_PATH = "/api-docs";
+export const CATALOG_PATH = "/.well-known/api-catalog";

--- a/src/pages/.well-known/api-catalog.ts
+++ b/src/pages/.well-known/api-catalog.ts
@@ -1,0 +1,56 @@
+import type { APIContext } from "astro";
+
+import {
+  DOCS_PATH,
+  HEALTH_MEDIA_TYPE,
+  HEALTH_PATH,
+  OPENAPI_PATH,
+  absoluteUrl,
+  apis,
+} from "../../lib/apiCatalog";
+
+/**
+ * RFC 9727 API catalog — https://www.rfc-editor.org/rfc/rfc9727
+ *
+ * Served from a function rather than prerendered so the `application/linkset+json`
+ * media type survives: a prerendered `/.well-known/api-catalog` has no file
+ * extension, so the host would fall back to guessing its content type.
+ */
+export const prerender = false;
+
+export async function GET({ site }: APIContext) {
+  const linkset = apis.map((api) => ({
+    anchor: absoluteUrl(api.anchorPath, site),
+    "service-desc": [
+      {
+        href: absoluteUrl(OPENAPI_PATH, site),
+        type: "application/openapi+json",
+        title: `OpenAPI description — ${api.name}`,
+      },
+    ],
+    "service-doc": [
+      {
+        href: `${absoluteUrl(DOCS_PATH, site)}#${api.id}`,
+        type: "text/html",
+        title: `Documentation — ${api.name}`,
+      },
+    ],
+    status: [
+      {
+        href: absoluteUrl(HEALTH_PATH, site),
+        type: HEALTH_MEDIA_TYPE,
+        title: "Service health",
+      },
+    ],
+  }));
+
+  return new Response(JSON.stringify({ linkset }, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/linkset+json",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
+      // The catalog describes public endpoints, so let any origin discover it.
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/src/pages/api-docs.astro
+++ b/src/pages/api-docs.astro
@@ -1,0 +1,316 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/Navbar.astro";
+import Footer from "../components/Footer.astro";
+import Badge from "../components/Badge.astro";
+import TextReveal from "../components/TextReveal.astro";
+import {
+  CATALOG_PATH,
+  DOCS_PATH,
+  HEALTH_MEDIA_TYPE,
+  HEALTH_PATH,
+  OPENAPI_PATH,
+  absoluteUrl,
+  apis,
+} from "../lib/apiCatalog";
+
+const pageTitle = "API Documentation - Rohit Kushwaha";
+const description =
+  "Reference for the public HTTP API of rohitk06.in: GitHub insights, link metadata, project repository data, and the contact endpoint. Discoverable via RFC 9727.";
+const canonicalURL = new URL(DOCS_PATH, Astro.site || Astro.url.origin).href;
+
+const site = Astro.site;
+const openapiUrl = absoluteUrl(OPENAPI_PATH, site);
+const catalogUrl = absoluteUrl(CATALOG_PATH, site);
+const healthUrl = absoluteUrl(HEALTH_PATH, site);
+const origin = absoluteUrl("", site);
+
+/** Example curl for an operation, with path/query templates filled in. */
+function exampleRequest(op: (typeof apis)[number]["operations"][number]) {
+  let path = op.path;
+  const query = new URLSearchParams();
+
+  for (const parameter of op.parameters ?? []) {
+    if (parameter.in === "path") {
+      path = path.replace(`{${parameter.name}}`, parameter.example);
+    } else {
+      query.set(parameter.name, parameter.example);
+    }
+  }
+
+  const url = `${origin}${path}${query.size ? `?${query}` : ""}`;
+
+  if (op.method === "get") return `curl "${url}"`;
+
+  const body = Object.keys(
+    (op.requestBody?.schema.properties as Record<string, unknown>) ?? {},
+  )
+    .map((key) => `"${key}": "..."`)
+    .join(", ");
+
+  return [
+    `curl -X POST "${url}" \\`,
+    `  -H "Content-Type: application/json" \\`,
+    `  -d '{ ${body} }'`,
+  ].join("\n");
+}
+---
+
+<Layout title={pageTitle} description={description} canonicalURL={canonicalURL}>
+  <div class="page-content relative z-0">
+    <Navbar />
+
+    <div
+      class="w-[95%] xs:w-[90%] sm:w-[85%] md:w-[80%] lg:w-[75%] xl:w-[70%] 2xl:w-[65%] relative z-20 mx-auto mt-[120px] md:mt-[160px] mb-32"
+    >
+      <!-- Header -->
+      <div
+        class="border border-[var(--border-color)] p-6 sm:p-8 md:p-12 relative"
+      >
+        <div class="size-4 bg-[var(--border-color)] absolute -top-2 -left-2">
+        </div>
+
+        <Badge size="sm" className="mb-4">
+          <span class="text-xs font-bold uppercase">API</span>
+        </Badge>
+
+        <TextReveal
+          element="h1"
+          text="API Documentation"
+          className="text-3xl sm:text-4xl md:text-5xl font-semibold split-text"
+          splitBy="chars"
+          stagger={0.03}
+          from="bottom"
+        />
+
+        <p
+          class="text-sm sm:text-base md:text-lg text-[var(--text-secondary)] mt-4 max-w-2xl"
+        >
+          The public HTTP API behind this site. Every endpoint is
+          unauthenticated — the read endpoints proxy GitHub with a server-side
+          token, so you don't spend your own rate limit.
+        </p>
+
+        <div class="flex flex-wrap gap-3 mt-6 text-xs sm:text-sm">
+          <a
+            href={OPENAPI_PATH}
+            class="px-3 py-2 border border-[var(--border-color)] hover:border-[var(--accent-primary)] hover:text-[var(--accent-primary)] transition-colors"
+            >OpenAPI 3.1 description</a
+          >
+          <a
+            href={CATALOG_PATH}
+            class="px-3 py-2 border border-[var(--border-color)] hover:border-[var(--accent-primary)] hover:text-[var(--accent-primary)] transition-colors"
+            >RFC 9727 catalog</a
+          >
+          <a
+            href={HEALTH_PATH}
+            class="px-3 py-2 border border-[var(--border-color)] hover:border-[var(--accent-primary)] hover:text-[var(--accent-primary)] transition-colors"
+            >Status</a
+          >
+        </div>
+      </div>
+
+      <!-- Discovery -->
+      <div
+        class="border border-[var(--border-color)] border-t-0 p-6 sm:p-8 md:p-12"
+      >
+        <h2 class="text-xl sm:text-2xl font-medium mb-4">Discovery</h2>
+        <p class="text-sm sm:text-base text-[var(--text-secondary)] mb-4">
+          These APIs are published as a machine-readable catalog at the
+          well-known location defined by
+          <a
+            href="https://www.rfc-editor.org/rfc/rfc9727"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-[var(--accent-primary)] hover:underline">RFC 9727</a
+          >. An agent can find every API, its description, its documentation,
+          and its health from one request:
+        </p>
+        <pre
+          class="text-xs sm:text-sm p-4 border border-[var(--border-color)] overflow-x-auto"><code>curl "{
+            catalogUrl
+          }"</code></pre>
+        <p class="text-xs sm:text-sm text-[var(--text-secondary)] mt-4">
+          The response is a <code class="text-[var(--accent-primary)]"
+            >application/linkset+json</code
+          > document. Each entry carries an <code>anchor</code> identifying the
+          API and the
+          <code>service-desc</code>, <code>service-doc</code>, and
+          <code>status</code> link relations.
+        </p>
+      </div>
+
+      <!-- Base URL -->
+      <div
+        class="border border-[var(--border-color)] border-t-0 p-6 sm:p-8 md:p-12"
+      >
+        <h2 class="text-xl sm:text-2xl font-medium mb-4">Base URL</h2>
+        <pre
+          class="text-xs sm:text-sm p-4 border border-[var(--border-color)] overflow-x-auto"><code>{
+            origin
+          }</code></pre>
+        <p class="text-xs sm:text-sm text-[var(--text-secondary)] mt-4">
+          Responses are JSON. Read endpoints are cached at the edge for one
+          hour and send
+          <code>Access-Control-Allow-Origin: *</code>.
+        </p>
+      </div>
+
+      <!-- APIs -->
+      {
+        apis.map((api) => (
+          <section
+            id={api.id}
+            class="border border-[var(--border-color)] border-t-0 p-6 sm:p-8 md:p-12 scroll-mt-32"
+          >
+            <h2 class="text-xl sm:text-2xl font-medium">{api.name}</h2>
+            <p class="text-sm sm:text-base text-[var(--text-secondary)] mt-3 max-w-3xl">
+              {api.description}
+            </p>
+
+            <div class="mt-8 space-y-8">
+              {api.operations.map((op) => (
+                <article class="border border-[var(--border-color)] p-4 sm:p-6">
+                  <div class="flex flex-wrap items-center gap-3">
+                    <span
+                      class:list={[
+                        "px-2 py-1 text-xs font-bold uppercase border",
+                        op.method === "get"
+                          ? "border-[var(--accent-primary)] text-[var(--accent-primary)]"
+                          : "border-[var(--border-color)]",
+                      ]}
+                    >
+                      {op.method}
+                    </span>
+                    <code class="text-sm sm:text-base break-all">{op.path}</code>
+                  </div>
+
+                  <h3 class="font-medium text-base sm:text-lg mt-4">
+                    {op.summary}
+                  </h3>
+                  <p class="text-sm text-[var(--text-secondary)] mt-2">
+                    {op.description}
+                  </p>
+
+                  {op.parameters?.length ? (
+                    <div class="mt-5">
+                      <h4 class="text-xs font-bold uppercase text-[var(--text-secondary)] mb-3">
+                        Parameters
+                      </h4>
+                      <ul class="space-y-2">
+                        {op.parameters.map((parameter) => (
+                          <li class="text-sm">
+                            <code class="text-[var(--accent-primary)]">
+                              {parameter.name}
+                            </code>
+                            <span class="text-[var(--text-secondary)]">
+                              {" "}
+                              — {parameter.in}
+                              {parameter.required ? ", required" : ", optional"}.{" "}
+                              {parameter.description}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+
+                  {op.requestBody ? (
+                    <div class="mt-5">
+                      <h4 class="text-xs font-bold uppercase text-[var(--text-secondary)] mb-3">
+                        Request body
+                      </h4>
+                      <p class="text-sm text-[var(--text-secondary)] mb-3">
+                        {op.requestBody.description}
+                      </p>
+                      <ul class="space-y-2">
+                        {Object.entries(
+                          (op.requestBody.schema.properties ?? {}) as Record<
+                            string,
+                            { description?: string }
+                          >,
+                        ).map(([name, field]) => (
+                          <li class="text-sm">
+                            <code class="text-[var(--accent-primary)]">
+                              {name}
+                            </code>
+                            <span class="text-[var(--text-secondary)]">
+                              {" "}
+                              — {field.description}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+
+                  <div class="mt-5">
+                    <h4 class="text-xs font-bold uppercase text-[var(--text-secondary)] mb-3">
+                      Responses
+                    </h4>
+                    <ul class="space-y-2">
+                      {op.responses.map((response) => (
+                        <li class="text-sm">
+                          <code class="text-[var(--accent-primary)]">
+                            {response.status}
+                          </code>
+                          <span class="text-[var(--text-secondary)]">
+                            {" "}
+                            — {response.description}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div class="mt-5">
+                    <h4 class="text-xs font-bold uppercase text-[var(--text-secondary)] mb-3">
+                      Example
+                    </h4>
+                    <pre class="text-xs sm:text-sm p-4 border border-[var(--border-color)] overflow-x-auto">
+                      <code>{exampleRequest(op)}</code>
+                    </pre>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+        ))
+      }
+
+      <!-- Health -->
+      <section
+        id="health"
+        class="border border-[var(--border-color)] border-t-0 p-6 sm:p-8 md:p-12 scroll-mt-32"
+      >
+        <h2 class="text-xl sm:text-2xl font-medium">Status</h2>
+        <p
+          class="text-sm sm:text-base text-[var(--text-secondary)] mt-3 max-w-3xl"
+        >
+          Every API in the catalog points its <code>status</code> relation at a
+          shared health endpoint, which answers with
+          <code>{HEALTH_MEDIA_TYPE}</code>.
+        </p>
+        <pre
+          class="text-xs sm:text-sm p-4 border border-[var(--border-color)] overflow-x-auto mt-5"><code>curl "{
+            healthUrl
+          }"</code></pre>
+      </section>
+
+      <!-- Footnote -->
+      <div
+        class="border border-[var(--border-color)] border-t-0 p-6 sm:p-8 md:p-12"
+      >
+        <p class="text-xs sm:text-sm text-[var(--text-secondary)]">
+          The machine-readable description at <a
+            href={OPENAPI_PATH}
+            class="text-[var(--accent-primary)] hover:underline">{openapiUrl}</a
+          > is generated from the same source as this page, so the two cannot drift
+          apart.
+        </p>
+      </div>
+    </div>
+
+    <Footer />
+  </div>
+</Layout>

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro";
+
+import { HEALTH_MEDIA_TYPE } from "../../lib/apiCatalog";
+
+/**
+ * Health endpoint advertised as the `status` link relation of every API in
+ * /.well-known/api-catalog. Shape follows the health-check response format
+ * (draft-inadarei-api-health-check).
+ *
+ * Served from a function so the response reflects the deployment that is
+ * actually answering, and is never cached.
+ */
+export const prerender = false;
+
+export const GET: APIRoute = async () => {
+  const body = {
+    status: "pass",
+    version: "1",
+    releaseId: import.meta.env.VERCEL_GIT_COMMIT_SHA ?? "dev",
+    serviceId: "rohitk06.in-portfolio-api",
+    description: "Public API for rohitk06.in",
+    time: new Date().toISOString(),
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": HEALTH_MEDIA_TYPE,
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+};

--- a/src/pages/openapi.json.ts
+++ b/src/pages/openapi.json.ts
@@ -1,0 +1,168 @@
+import type { APIContext } from "astro";
+
+import {
+  DOCS_PATH,
+  HEALTH_MEDIA_TYPE,
+  HEALTH_PATH,
+  absoluteUrl,
+  apis,
+  type ApiOperation,
+} from "../lib/apiCatalog";
+
+/**
+ * OpenAPI 3.1 description of the public API, generated from `src/lib/apiCatalog.ts`.
+ * This is the `service-desc` target advertised by /.well-known/api-catalog.
+ *
+ * Served from a function rather than prerendered so it answers with the
+ * `application/openapi+json` type the catalog advertises; a prerendered file
+ * would be served as plain `application/json` off its extension.
+ */
+export const prerender = false;
+
+function jsonContent(schema: Record<string, unknown>) {
+  return { "application/json": { schema } };
+}
+
+function buildOperation(api: { id: string; name: string }, op: ApiOperation) {
+  const responses: Record<string, unknown> = {};
+  for (const response of op.responses) {
+    responses[response.status] = {
+      description: response.description,
+      ...(response.schema ? { content: jsonContent(response.schema) } : {}),
+    };
+  }
+
+  return {
+    tags: [api.id],
+    operationId: op.operationId,
+    summary: op.summary,
+    description: op.description,
+    ...(op.parameters?.length
+      ? {
+          parameters: op.parameters.map((parameter) => ({
+            name: parameter.name,
+            in: parameter.in,
+            required: parameter.required,
+            description: parameter.description,
+            schema: { type: "string" },
+            example: parameter.example,
+          })),
+        }
+      : {}),
+    ...(op.requestBody
+      ? {
+          requestBody: {
+            required: true,
+            description: op.requestBody.description,
+            content: jsonContent(op.requestBody.schema),
+          },
+        }
+      : {}),
+    responses,
+  };
+}
+
+export async function GET({ site }: APIContext) {
+  const paths: Record<string, Record<string, unknown>> = {};
+
+  for (const api of apis) {
+    for (const op of api.operations) {
+      paths[op.path] ??= {};
+      paths[op.path][op.method] = buildOperation(api, op);
+    }
+  }
+
+  paths[HEALTH_PATH] = {
+    get: {
+      tags: ["health"],
+      operationId: "getHealth",
+      summary: "Service health",
+      description:
+        "Liveness of the API, in the health-check response format. Advertised as the `status` link relation for every API in the catalog.",
+      responses: {
+        "200": {
+          description: "The API is serving requests.",
+          content: {
+            [HEALTH_MEDIA_TYPE]: {
+              schema: {
+                type: "object",
+                properties: {
+                  status: {
+                    type: "string",
+                    enum: ["pass"],
+                    description: "Overall health of the service.",
+                  },
+                  version: { type: "string" },
+                  serviceId: { type: "string" },
+                  description: { type: "string" },
+                  time: { type: "string", format: "date-time" },
+                },
+                required: ["status"],
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const document = {
+    openapi: "3.1.0",
+    info: {
+      title: "Rohit Kushwaha — Portfolio API",
+      version: "1.0.0",
+      summary: "Public read-only APIs backing rohitk06.in, plus the contact endpoint.",
+      description: [
+        "The public HTTP API of [rohitk06.in](https://rohitk06.in).",
+        "",
+        "Every endpoint is unauthenticated. The read endpoints proxy GitHub with a",
+        "server-side token and are cached at the edge, so callers do not need",
+        "credentials and are not billed against their own GitHub rate limit.",
+        "",
+        `Human-readable documentation lives at ${absoluteUrl(DOCS_PATH, site)}.`,
+      ].join("\n"),
+      contact: {
+        name: "Rohit Kushwaha",
+        url: absoluteUrl("/contact", site),
+      },
+      license: {
+        name: "MIT",
+        url: "https://github.com/DevRohit06/portfolio/blob/main/LICENSE",
+      },
+    },
+    servers: [
+      {
+        url: absoluteUrl("", site),
+        description: "Production",
+      },
+    ],
+    tags: [
+      ...apis.map((api) => ({
+        name: api.id,
+        description: api.description,
+        externalDocs: {
+          description: `Documentation for the ${api.name}`,
+          url: `${absoluteUrl(DOCS_PATH, site)}#${api.id}`,
+        },
+      })),
+      {
+        name: "health",
+        description: "Liveness reporting shared by every API in the catalog.",
+      },
+    ],
+    externalDocs: {
+      description: "API documentation",
+      url: absoluteUrl(DOCS_PATH, site),
+    },
+    paths,
+  };
+
+  return new Response(JSON.stringify(document, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/openapi+json",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}


### PR DESCRIPTION
Publishes an API catalog at `/.well-known/api-catalog` so automated clients
can discover this site's HTTP API from a single request, per
[RFC 9727](https://www.rfc-editor.org/rfc/rfc9727).

## What's here

`/.well-known/api-catalog` serves an `application/linkset+json` document with
one entry per API — GitHub Insights, Link Metadata, Project Repository, and
Contact. Each entry carries an `anchor` plus the `service-desc`, `service-doc`,
and `status` link relations, matching the shape of
[Appendix A.1](https://www.rfc-editor.org/rfc/rfc9727#appendix-A).

A catalog is only useful if the things it points at exist, so this also adds
the three targets:

| Route | Purpose |
| --- | --- |
| `/openapi.json` | OpenAPI 3.1 description of every endpoint (`service-desc`) |
| `/api-docs` | Human-readable reference (`service-doc`) |
| `/api/health` | Liveness, in the health-check response format (`status`) |

All four are generated from `src/lib/apiCatalog.ts`, so the machine
description, the docs page, and the catalog cannot drift apart. Adding an
endpoint in one place updates all of them.

Every page also advertises the catalog via `<link rel="api-catalog">`, which
is RFC 9727's second discovery mechanism.

## Why these routes aren't prerendered

The catalog, spec, and health routes set `prerender = false` on purpose.
A prerendered `/.well-known/api-catalog` has no file extension, so the host
would guess its content type and the `application/linkset+json` requirement
would silently fail. The same reasoning applies to `/openapi.json`: as a
static file it would be served `application/json`, contradicting the
`application/openapi+json` the catalog advertises.

`/api-docs` stays static.

## Verification

Checked against a running dev server:

- `200` and `Content-Type: application/linkset+json`
- All 4 entries have `anchor` + `service-desc` + `service-doc` + `status`
- Every advertised `href` resolves
- Declared media type matches served media type for every link
- OpenAPI path params match their `{templates}`; every operation has an
  `operationId` and responses
- Every `service-doc` fragment exists as an `id` on `/api-docs`

The production build emits the expected Vercel routing: functions for the
three dynamic routes, static HTML for `/api-docs`.

Not yet confirmed: `checks.discovery.apiCatalog` reporting `"pass"` from
isitagentready.com. Preview deploys sit behind Vercel Deployment Protection,
so the scanner receives a 302 to an SSO login. It can only be validated once
this is on production:

```
curl -s -X POST https://isitagentready.com/api/scan \
  -H "Content-Type: application/json" \
  -d '{"url": "https://rohitk06.in"}' | jq .checks.discovery.apiCatalog.status
```

A baseline scan before this change returned `"fail"` with a 404, and the 404
came back as Astro's own error page through Cloudflare — so `/.well-known/*`
already reaches the Vercel origin and needs no proxy change.

## Two judgement calls worth a look

- **No `profile` parameter on the content type.** RFC 9727 says the media type
  SHOULD carry `profile="https://www.rfc-editor.org/info/rfc9727"`. It's
  omitted because a scanner comparing the content type by exact string would
  fail on the parameter. Trivial to add once we've seen the check pass.
- **`/api/github/last-updated-file` is excluded.** It queries the unrelated
  `jestsee/jestsee.com` repository and reads as template leftover rather than
  part of this site's API. Happy to include it if that's wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
