### PR TITLE
Fix wrong email on the contact page

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -23,9 +23,9 @@ const canonicalURL = new URL("/contact", Astro.site || Astro.url.origin).href;
 const socialLinks = [
   {
     name: "Email",
-    href: "mailto:rohitk2006@gmail.com",
+    href: "mailto:rohitk290106@gmail.com",
     icon: "mdi:email",
-    username: "rohitk2006@gmail.com",
+    username: "rohitk290106@gmail.com",
   },
   {
     name: "GitHub",
@@ -62,7 +62,7 @@ const jsonLd = {
   mainEntity: {
     "@type": "Person",
     name: "Rohit Kushwaha",
-    email: "rohitk2006@gmail.com",
+    email: "rohitk290106@gmail.com",
     sameAs: socialLinks.map((s) => s.href),
   },
 };


### PR DESCRIPTION
`src/pages/contact.astro` used **`rohitk2006@gmail.com`** in three places, while every other file in the repo (`AboutMe`, `Faq`, `Skills`, `lib/socials.ts`, `api/contact.ts`, `uses`, `projects/ocopus`) uses **`rohitk290106@gmail.com`**.

Fixed all three:
- the `mailto:` href
- the visible username under Email
- the `email` field in the Person JSON-LD

The last one matters beyond the click: structured data is what search engines ingest, so the wrong address was being published as the canonical contact for the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)